### PR TITLE
show participants in the session page

### DIFF
--- a/repl-sessions/participants.clj
+++ b/repl-sessions/participants.clj
@@ -1,0 +1,43 @@
+(ns repl-sessions.participants
+  "Prepare some testing data for testing participants in a session.
+
+   How to use:
+   1. You create a session and get the session id from the URL 
+   2. Run this participants namespace to create another 10 temp users
+   3. Go to the sessions/:id page to do the revoke testing
+  "
+  (:require
+   [co.gaiwan.compass.db :as db]
+   [co.gaiwan.compass.model.assets :as assets]
+   [datomic.api :as d]))
+
+(def new-session-eid
+  17592186045520)
+;; Avatar source URL https://github.com/alohe/avatars
+(defn temp-user-tx
+  " Create the user txes
+
+    1. Download some testing avatar image from remote URL
+    2. Create 10 testing users with temp name adn temp avatar
+    3. Build participating relationship with session: `eid`"
+  [eid]
+  (let [avatar-url-part "https://cdn.jsdelivr.net/gh/alohe/avatars/png/vibrent_"]
+    (concat
+     (mapv
+      (fn [x]
+        {:db/id (str "temp-" x)
+         :discord/email (str "temp-email-" x "@gaiwan.co")
+         :public-profile/name (str "temp-user-" x)
+         :public-profile/avatar-url (assets/download-image (str avatar-url-part x ".png"))})
+      (range 1 11))
+     ;; Below is for session join
+     (mapv
+      (fn [x]
+        {:db/id eid
+         :session/participants (str "temp-" x)})
+      (range 1 11)))))
+
+(def tx (temp-user-tx
+         new-session-eid))
+
+(db/transact tx)

--- a/repl-sessions/participants.clj
+++ b/repl-sessions/participants.clj
@@ -1,10 +1,10 @@
 (ns repl-sessions.participants
-  "Prepare some testing data for testing participants in a session.
+  "Prepare some testing data for showing participants in a session.
 
    How to use:
    1. You create a session and get the session id from the URL 
    2. Run this participants namespace to create another 10 temp users
-   3. Go to the sessions/:id page to do the revoke testing
+   3. Go to the sessions/:id page to do the testing
   "
   (:require
    [co.gaiwan.compass.db :as db]

--- a/src/co/gaiwan/compass/html/sessions.clj
+++ b/src/co/gaiwan/compass/html/sessions.clj
@@ -161,7 +161,6 @@
 
     [img+join-widget session user]
 
-
     [:div.details
      [:h2.title
       [:a {:href (url-for :session/get {:id (:db/id session)})}
@@ -180,12 +179,21 @@
    ["0%, 100%" {:opacity 1}]
    ["50%" {:opacity 0.5}]))
 
-(o/defstyled attendee :li
-  ([participant]
+(o/defstyled attendee :div
+  :flex :items-center :my-2 :py-2
+  :shadow-2 :font-size-3
+  {:background-color t/--surface-2}
+  [:.details :flex-grow :mr-2]
+  [c/image-frame :w-50px {--arc-thickness "7%"} :mx-2]
+  ([p]
    ;; (prn "debug datatype " (type participant))
    ;; participant is of `Datomic.query.EntityMap` type
    ;; So, we can access its attribute directly
-   (:user/handle participant)))
+   [:<>
+    [c/image-frame {:profile/image (user/avatar-css-value p)}]
+    [:div.details
+     [:div.profile-name (:public-profile/name p)]
+     [:div.email (:discord/email p)]]]))
 
 (o/defstyled session-detail :div
   [capacity-gauge :w-100px]
@@ -277,8 +285,10 @@
      (when (session/organizing? session user)
        ;; Only show the participants' list to organizer.
        [:div.participants
-        [:div "Participants:"]
-        [:ol (map attendee participants)]])
+        [:h3 "Participants"]
+        #_(pr-str participants)
+        (for [p participants]
+          [attendee p])])
 
      [:div.actions
 
@@ -294,8 +304,6 @@
          [:a {:href (url-for :session/edit {:id (:db/id session)})}
           [:button  "Edit"]]
          [:button {:hx-delete (url-for :session/get {:id (:db/id session)})} "Delete"]])]
-     #_[:p.host "Organized by " organized]
-     #_[:ol (map attendee participants)]
      #_[:p (pr-str user)]
      #_[:p (pr-str session)]]]))
 
@@ -371,9 +379,9 @@
                         (str (time/local-date (:session/time session)))
                         (str (java.time.LocalDate/now)))}]
       [:input (cond->
-                  {:id "start-time" :name "start-time" :type "time"
-                   :min "06:00" :max "23:00" :required true
-                   :step 60}
+               {:id "start-time" :name "start-time" :type "time"
+                :min "06:00" :max "23:00" :required true
+                :step 60}
                 session
                 (assoc :value
                        (str (time/local-time (:session/time session)))))]]
@@ -415,17 +423,15 @@
       (when session
         (:session/description session))]
 
-     #_
-     [:label {:for "ticket"}
-      [:input {:id "ticket" :name "ticket-required?" :type "checkbox"
-               :checked (:session/ticket-required? session)}]
-      "Requires Ticket?"]
+     #_[:label {:for "ticket"}
+        [:input {:id "ticket" :name "ticket-required?" :type "checkbox"
+                 :checked (:session/ticket-required? session)}]
+        "Requires Ticket?"]
 
-     #_
-     [:label {:for "published"}
-      [:input {:id "published" :name "published?" :type "checkbox"
-               :checked (:session/published? session)}]
-      "Published/Visible?"]
+     #_[:label {:for "published"}
+        [:input {:id "published" :name "published?" :type "checkbox"
+                 :checked (:session/published? session)}]
+        "Published/Visible?"]
 
      (when session
        [session-image+guage session user])


### PR DESCRIPTION
- [x] create a `repl-sessions/participants.clj` file to create temp participants to join the session. 
- [x] show basic information of the participant
- [x] reuse the css from contact page. 

<img width="143" alt="截圖 2024-09-10 下午10 47 49" src="https://github.com/user-attachments/assets/e7109855-764c-4545-a5e8-c041cc83c0bc">
