### PR TITLE
Laurence/issue 40 new

### DIFF
--- a/repl-sessions/participants.clj
+++ b/repl-sessions/participants.clj
@@ -12,7 +12,7 @@
    [datomic.api :as d]))
 
 (def new-session-eid
-  17592186045520)
+  17592186045455)
 ;; Avatar source URL https://github.com/alohe/avatars
 (defn temp-user-tx
   " Create the user txes
@@ -27,6 +27,7 @@
       (fn [x]
         {:db/id (str "temp-" x)
          :discord/email (str "temp-email-" x "@gaiwan.co")
+         :public-profile/hidden? (if (even? x) true false)
          :public-profile/name (str "temp-user-" x)
          :public-profile/avatar-url (assets/download-image (str avatar-url-part x ".png"))})
       (range 1 11))

--- a/repl-sessions/participants.clj
+++ b/repl-sessions/participants.clj
@@ -11,6 +11,19 @@
    [co.gaiwan.compass.model.assets :as assets]
    [datomic.api :as d]))
 
+(defn test-user-eid
+  "Query the database to find out a certain login by discord user"
+  [user-name]
+  (db/q
+   '[:find ?e .
+     :in $ ?u
+     :where
+     [?e :public-profile/name ?u]]
+   (db/db) user-name))
+
+(def user-eid
+  (test-user-eid "Laurence"))
+
 (def new-session-eid
   17592186045455)
 ;; Avatar source URL https://github.com/alohe/avatars
@@ -27,9 +40,13 @@
       (fn [x]
         {:db/id (str "temp-" x)
          :user/uuid (random-uuid)
+         :user/contacts user-eid
          :discord/email (str "temp-email-" x "@gaiwan.co")
          :public-profile/hidden? (if (even? x) true false)
          :public-profile/name (str "temp-user-" x)
+         :public-profile/bio "problic-bio"
+         :private-profile/bio "private-bio"
+         :private-profile/name "private-name"
          :public-profile/avatar-url (assets/download-image (str avatar-url-part x ".png"))})
       (range 1 11))
      ;; Below is for session join

--- a/repl-sessions/participants.clj
+++ b/repl-sessions/participants.clj
@@ -26,6 +26,7 @@
      (mapv
       (fn [x]
         {:db/id (str "temp-" x)
+         :user/uuid (random-uuid)
          :discord/email (str "temp-email-" x "@gaiwan.co")
          :public-profile/hidden? (if (even? x) true false)
          :public-profile/name (str "temp-user-" x)

--- a/src/co/gaiwan/compass/html/profiles.clj
+++ b/src/co/gaiwan/compass/html/profiles.clj
@@ -20,11 +20,15 @@
 (o/defstyled profile-detail :div#detail
   [c/image-frame :w-100px {t/--arc-thickness "7%"}]
   [:.details
+   [:.bio :mt-2]
    [:.links :my-2]
    [:.link :w-full :flex :flex-1 :py-1 :font-size-3]
    [:.link-type :w-12 :px-2]
    [:.link-ref :flex-grow :px-2]]
-  [:.contact-card :my-2]
+  [:.contact-card :my-6 :shadow-3
+   {:background-color t/--surface-2
+    :padding t/--size-3
+    :border-radius t/--size-2}]
   ([{:public-profile/keys [name hidden?]
      :user/keys [uuid] :as user} viewer]
    [:<>

--- a/src/co/gaiwan/compass/html/profiles.clj
+++ b/src/co/gaiwan/compass/html/profiles.clj
@@ -24,22 +24,35 @@
    [:.link :w-full :flex :flex-1 :py-1 :font-size-3]
    [:.link-type :w-12 :px-2]
    [:.link-ref :flex-grow :px-2]]
-
+  [:.contact-card :my-2]
   ([{:public-profile/keys [name hidden?]
      :user/keys [uuid] :as user} viewer]
    [:<>
     [:div [c/image-frame {:profile/image (user/avatar-css-value user)}]]
     [:div.details
      [:h3.title name]
-     [:div.bio
-      (m/component (m/md->hiccup (:public-profile/bio user)))]
+     (when (:public-profile/bio user)
+       [:div.bio
+        (m/component (m/md->hiccup (:public-profile/bio user)))])
      [:div.links
       (for [link (:public-profile/links user)]
         [:div.link
          [:div.link-type (:profile-link/type link)]
          [:div.link-ref (:profile-link/href link)]])]]
-
-;; hide edit button unless it's your own profile
+    ;; if the user is connected (contact), show "contact card"
+    (when (some #{(:db/id viewer)} (map :db/id (:user/contacts user)))
+      [:div.contact-card
+       [:div.details
+        [:h3.title (:private-profile/name user)]
+        (when (:private-profile/bio user)
+          [:div.bio
+           (m/component (m/md->hiccup (:private-profile/bio user)))])
+        [:div.links
+         (for [link (:private-profile/links user)]
+           [:div.link
+            [:div.link-type (:profile-link/type link)]
+            [:div.link-ref (:profile-link/href link)]])]]])
+    ;; hide edit button unless it's your own profile
     (when (= (:db/id viewer) (:db/id user))
       [:div.actions
        [edit-profile-btn user]])]))

--- a/src/co/gaiwan/compass/html/sessions.clj
+++ b/src/co/gaiwan/compass/html/sessions.clj
@@ -198,7 +198,7 @@
    [:<>
     [c/image-frame {:profile/image (user/avatar-css-value p)}]
     [:div.details
-     [:a {:href (url-for :profile/show {:profile-id (:user/uuid p)})}
+     [:a {:href (url-for :profile/show {:user-uuid (:user/uuid p)})}
       [:div.profile-name (:public-profile/name p)]]]]))
 
 (o/defstyled session-detail :div

--- a/src/co/gaiwan/compass/html/sessions.clj
+++ b/src/co/gaiwan/compass/html/sessions.clj
@@ -179,6 +179,12 @@
    ["0%, 100%" {:opacity 1}]
    ["50%" {:opacity 0.5}]))
 
+(o/defstyled handle-the-hidden :div
+  ([participants]
+   (let [hiddens (count (filter #(:public-profile/hidden? %) participants))]
+     (when (pos? hiddens)
+       (str "and " hiddens " more")))))
+
 (o/defstyled attendee :div
   :flex :items-center :my-2 :py-2
   :shadow-2 :font-size-3
@@ -282,13 +288,13 @@
          (if (:session/ticket-required? session)
            [:p.large "YES ✅"]
            [:p.large "NO ❎"])]]
-     (when (session/organizing? session user)
-       ;; Only show the participants' list to organizer.
-       [:div.participants
-        [:h3 "Participants"]
-        #_(pr-str participants)
-        (for [p participants]
-          [attendee p])])
+     #_(when (session/organizing? session user))
+     [:div.participants
+      [:h3 "Participants"]
+      (for [p participants]
+        (when-not (:public-profile/hidden? p)
+          [attendee p]))
+      [handle-the-hidden participants]]
 
      [:div.actions
 

--- a/src/co/gaiwan/compass/html/sessions.clj
+++ b/src/co/gaiwan/compass/html/sessions.clj
@@ -198,7 +198,8 @@
    [:<>
     [c/image-frame {:profile/image (user/avatar-css-value p)}]
     [:div.details
-     [:div.profile-name (:public-profile/name p)]]]))
+     [:a {:href (url-for :profile/show {:profile-id (:user/uuid p)})}
+      [:div.profile-name (:public-profile/name p)]]]]))
 
 (o/defstyled session-detail :div
   [capacity-gauge :w-100px]

--- a/src/co/gaiwan/compass/routes/profiles.clj
+++ b/src/co/gaiwan/compass/routes/profiles.clj
@@ -15,6 +15,7 @@
    [ring.util.response :as ring-response]))
 
 (defn GET-profile [{:keys [params] :as req}]
+  (tap> {:params params})
   {:html/body
    [h/profile-detail
     (if-let [user-uuid (:user-uuid params)]
@@ -90,7 +91,7 @@
 (defn parse-link-data [params variant]
   (map vector
        (get params (keyword (str variant "-link-type")))
-       (get params (keyword (str variant "-link-ref"))))  )
+       (get params (keyword (str variant "-link-ref")))))
 
 (defn reconcile-links [user-id variant old-links new-links]
   (let [existing-pairs (map (juxt :profile-link/type :profile-link/href) old-links)
@@ -149,8 +150,7 @@
       (conj [:db/retract user-id :private-profile/name (:private-profile/name user)])
 
       (not (str/blank? name_private))
-      (conj [:db/add user-id :private-profile/name name_private])
-      )))
+      (conj [:db/add user-id :private-profile/name name_private]))))
 
 (defn POST-save-profile
   "Save profile to DB

--- a/src/co/gaiwan/compass/routes/profiles.clj
+++ b/src/co/gaiwan/compass/routes/profiles.clj
@@ -20,7 +20,7 @@
   ;; (log/debug :debug {:req req})
   {:html/body
    [h/profile-detail
-    (if-let [profile-id (get-in req [:path-params :profile-id])]
+    (if-let [profile-id (get-in req [:path-params :user-uuid])]
       (db/entity [:user/uuid (parse-uuid profile-id)])
       (:identity req)) (:identity req)]})
 

--- a/src/co/gaiwan/compass/routes/profiles.clj
+++ b/src/co/gaiwan/compass/routes/profiles.clj
@@ -17,12 +17,12 @@
    [ring.util.response :as ring-response]))
 
 (defn GET-profile [{:keys [params] :as req}]
-  (log/debug :debug {:req req})
+  ;; (log/debug :debug {:req req})
   {:html/body
    [h/profile-detail
     (if-let [profile-id (get-in req [:path-params :profile-id])]
       (db/entity [:user/uuid (parse-uuid profile-id)])
-      (:identity req))]})
+      (:identity req)) (:identity req)]})
 
 (defn GET-profile-form [req]
   {:html/body [h/profile-form

--- a/src/co/gaiwan/compass/routes/profiles.clj
+++ b/src/co/gaiwan/compass/routes/profiles.clj
@@ -4,6 +4,7 @@
    [clj.qrgen :as qr]
    [clojure.java.io :as io]
    [clojure.string :as str]
+   [io.pedestal.log :as log]
    [co.gaiwan.compass.config :as config]
    [co.gaiwan.compass.db :as db]
    [co.gaiwan.compass.db.queries :as q]
@@ -12,14 +13,15 @@
    [co.gaiwan.compass.http.routing :refer [url-for]]
    [co.gaiwan.compass.model.assets :as assets]
    [co.gaiwan.compass.model.attendees :as attendees]
+
    [ring.util.response :as ring-response]))
 
 (defn GET-profile [{:keys [params] :as req}]
-  (tap> {:params params})
+  (log/debug :debug {:req req})
   {:html/body
    [h/profile-detail
-    (if-let [user-uuid (:user-uuid params)]
-      (db/entity [:user/uuid user-uuid])
+    (if-let [profile-id (get-in req [:path-params :profile-id])]
+      (db/entity [:user/uuid (parse-uuid profile-id)])
       (:identity req))]})
 
 (defn GET-profile-form [req]


### PR DESCRIPTION
- [x] On session/activity pages, hide users that are `:public-profile/hidden?`
  - don't show them in the list
  - at the bottom say "n more", e.g. `and 5 more`
- [x] On the session/activity  -> link to user profile `/user/:uuid`
- Profile page
  - [x] hide edit button unless it's your own profile
  - [x] show public display name
  - [x] show public bio (markdown)
  - [x] show public links
  - [x] if the user is connected (contact), show "contact card"
     - private name
     - private bio
     - private links