### PR TITLE
Remove the grid layout

### DIFF
--- a/src/co/gaiwan/compass/html/sessions.clj
+++ b/src/co/gaiwan/compass/html/sessions.clj
@@ -321,10 +321,7 @@
 (o/defstyled session-list :section#sessions
   [:.sessions
    :grid :gap-3
-   {:grid-template-columns "repeat(1, 1fr)"}
-   [:at-media {:min-width "40rem"} {:grid-template-columns "repeat(1, 1fr)"}]
-   [:at-media {:min-width "60rem"} {:grid-template-columns "repeat(2, 1fr)"}]
-   #_[:at-media {:min-width "80rem"} {:grid-template-columns "repeat(3, 1fr)"}]]
+   {:grid-template-columns "repeat(1, 1fr)"}]
   [:>h2 :mb-4 :mt-7
    {:font-size t/--font-size-3}
    ["&:first-child" :mt-0]


### PR DESCRIPTION
Arguably, the grid is not a good fit. We're working with a single stream UX as opposed to several sessions happening at once, and it just makes way more sense that all the data is presented in a single column.

It makes the presentation slightly worse on wide screens, but also makes it significantly less confusing in re. overlapping times.

Instead if zig-zagging with your eyeballs, you get the single calendar-style event list now no matter the screen width.